### PR TITLE
メッセージ生成の回数緩和

### DIFF
--- a/app/controllers/ai_messages_controller.rb
+++ b/app/controllers/ai_messages_controller.rb
@@ -10,11 +10,6 @@ class AiMessagesController < ApplicationController
   end
 
   def generate
-    # 生成回数の制限
-    if reached_daily_word_limit?
-      return render_limit_reached
-    end
-
     target, situation = find_or_create_target_and_situation
     if target.nil? || situation.nil?
       return render_missing_input
@@ -90,17 +85,6 @@ class AiMessagesController < ApplicationController
     [ target, situation ]
   end
 
-  def render_limit_reached
-    respond_to do |format|
-      format.html {
-        redirect_to new_ai_message_path(error: "一日の生成回数制限に達しました(上限5回)")
-      }
-      format.json {
-        render json: { error: "一日の生成回数制限に達しました(上限5回)" }, status: :forbidden
-      }
-    end
-  end
-
   def render_missing_input
     respond_to do |format|
       format.html {
@@ -110,10 +94,6 @@ class AiMessagesController < ApplicationController
         render json: { error: "対象人物とシチュエーションは必須です。" }, status: :unprocessable_entity
       }
     end
-  end
-
-  def reached_daily_word_limit?
-    current_user.positive_words.where(created_at: Time.zone.today.all_day).count >= 5
   end
 
   def prepare_meta_tags(positive_word)

--- a/app/services/ai_messages_generator.rb
+++ b/app/services/ai_messages_generator.rb
@@ -1,13 +1,13 @@
 class AiMessagesGenerator
   def self.call(target_name:, situation_name:)
-    prompt = "#{target_name}が#{situation_name}ときに贈る、ほめたり、肯定したりなどポジティブになれる会話文のような短いメッセージまたはワードを1つ考えてください。出力はそのメッセージ、またはワードの本文のみを日本語で返してください。番号付け、複数回答、説明や挨拶などは不要です。過去に生成されたメッセージ・ワードと重複しないようにしてください。"
+    prompt = "#{target_name}が#{situation_name}ときに贈る、ほめたり、肯定したりなどポジティブになれる会話文のような短いメッセージまたはワードを1つ考えてください。出力はそのメッセージ、またはワードの本文のみを日本語で返してください。親しみやすいカジュアルな口調で書いてください。番号付け、複数回答、説明や挨拶などは不要です。過去に生成されたメッセージ・ワードと重複しないようにしてください。"
 
     client = OpenAI::Client.new
     response = client.chat(
       parameters: {
         model: "gpt-4.1-mini",
         messages: [ { role: "user", content: prompt } ],
-        temperature: 0.8
+        temperature: 0.9
       }
     )
 

--- a/app/views/ai_messages/new.html.erb
+++ b/app/views/ai_messages/new.html.erb
@@ -23,10 +23,6 @@
       <p class="text-md text-gray-600 text-center">
         下のフォームに自由に書いてみて！
       </p>
-
-      <p class="text-md text-red-600 text-center mt-2 font-semibold">
-        ※作成は1日5回まで
-      </p>
     </div>
 
     <div class="p-6">

--- a/app/views/pages/how_to_use/ai_messages.html.erb
+++ b/app/views/pages/how_to_use/ai_messages.html.erb
@@ -29,10 +29,7 @@
               </p>
               <p>
                 その後、<strong>「ワードを作る」</strong> ボタンを選択すると、対象人物とシチュエーションに合わせたポジティブなワードがAIによって生成されます。
-              </p>
-              <p>
-                <strong class="text-red-600">作成は一日5回までとなります</strong>
-              </p>              
+              </p>            
             </div>
 
             <div class="md:w-1/2 flex items-start">

--- a/app/views/top/_card_features.html.erb
+++ b/app/views/top/_card_features.html.erb
@@ -5,14 +5,13 @@
       <i class="bi bi-lightbulb text-pink-500 text-2xl"></i>
     </div>
     <h3 class="text-xl font-bold text-pink-600 mb-3 text-ellipsis">ポジティブワードを知る</h3>
-    <p class="text-gray-600 leading-relaxed flex-grow text-sm text-left px-8 font-semibold">
+    <p class="text-gray-600 leading-relaxed flex-grow text-sm text-left px-8 mb-4 font-semibold">
       「誰に」「どんな」言葉を送りたい？
 
     シチュエーションに合わせて、
     
       AIがポジティブなワードを作成します。
     </p>
-    <span class="block text-red-600 text-lg font-bold mt-4 mb-4">※ワードの作成は1日5回まで</span>
 
     <div class="mb-4"> 
       <%= image_tag "ai_messages/ai_messages_top.png", alt: "作るの画面の例", class: "rounded-lg w-full max-w-[200px] mx-auto mb-3 h-auto object-contain" %>

--- a/spec/system/user_pages_spec.rb
+++ b/spec/system/user_pages_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "UserPages", type: :system do
 
         find('[data-testid="menu-toggle"]', match: :first).click
         within "#bookmark-button-for-word-#{positive_word.id}" do
-          expect(page).to have_link('いいね', wait: 10)
+          expect(page).to have_link('いいね', wait: 5)
           find('a', text: 'いいね', wait: 10).click
         end
         


### PR DESCRIPTION
# 概要
**卒業制作⑯本リリースに向けての対応**
メッセージ生成の回数緩和

# 実装内容
- [x] AIで生成するメッセージの回数を緩和
- ai_meaages_controller.rbからdef limitを削除
- ai_meaagesの説明文で作成回数に関するテキストを削除
- AIメッセージのプロンプトを強化


# 確認方法
- [x] /ai_meaagesで5回の回数制限がなくなっているか確認

