### PR TITLE
管理者画面の追加

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,0 +1,43 @@
+class Admin::PostsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :if_not_admin
+  before_action :set_post, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @posts = Post.all.order(created_at: :desc)
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @post.update(post_params)
+      redirect_to admin_posts_path(@post), notice: "投稿を更新しました"
+    else
+      flash.now[:alert] = "投稿の更新に失敗しました"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @post.destroy
+    redirect_to admin_posts_path, alert: "投稿を削除しました"
+  end
+
+  private
+
+  def if_not_admin
+    redirect_to root_path, alert: "管理者専用ページです" unless current_user&.admin?
+  end
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  def post_params
+    params.require(:post).permit(:post_word, :caption)
+  end
+end

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -1,0 +1,24 @@
+<% set_meta_tags title: "管理者ページ | 投稿編集" %>
+
+<div class="container mx-auto px-4 py-16">
+
+  <div class="max-w-xl mx-auto bg-white p-8 rounded-lg shadow-md">
+    <h1 class="text-3xl font-bold text-gray-800 mb-6 text-center">投稿編集</h1>
+    <%= form_with model: [:admin, @post], local: true, class: "space-y-6" do |f| %>
+      <div>
+        <%= f.label :post_word, "ポジほめワード", class: "block text-sm font-medium text-gray-700" %>
+        <%= f.text_field :post_word, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-red-500 focus:ring-red-500 sm:text-sm" %>
+      </div>
+
+      <div>
+        <%= f.label :caption, "キャプション", class: "block text-sm font-medium text-gray-700" %>
+        <%= f.text_area :caption, rows: 5, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-red-500 focus:ring-red-500 sm:text-sm" %>
+      </div>
+
+      <div class="flex justify-end space-x-3">
+        <%= link_to 'キャンセル', admin_posts_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+        <%= f.submit '更新', class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,0 +1,54 @@
+<% set_meta_tags title: "管理者ページ | 投稿管理" %>
+
+<div class="container mx-auto px-4 py-16">
+
+
+  <div class="bg-white shadow-md rounded-lg overflow-hidden">
+    <h1 class="text-3xl font-bold text-gray-800 mb-6 text-center">投稿管理</h1>
+    <table class="min-w-full leading-normal">
+      <thead>
+        <tr>
+          <th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+            投稿ID
+          </th>
+          <th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+            ポジほめワード
+          </th>
+          <th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+            投稿者
+          </th>
+          <th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+            投稿日時
+          </th>
+          <th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">
+            アクション
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @posts.each do |post| %>
+          <tr class="hover:bg-gray-50">
+            <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+              <%= post.id %>
+            </td>
+            <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+              <%= link_to post.post_word, admin_post_path(post), class: "text-blue-600 hover:text-blue-800" %>
+            </td>
+            <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+              <%= post.user.username %>
+            </td>
+            <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+              <%= l post.created_at, format: :short %>
+            </td>
+            <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm text-center">
+              <%= link_to '編集', edit_admin_post_path(post), class: 'text-indigo-600 hover:text-indigo-900 mr-4' %>
+              <%= link_to '削除', admin_post_path(post),
+                          data: { turbo_method: :delete, turbo_confirm: '本当にこの投稿を削除しますか？' },
+                          class: 'text-red-600 hover:text-red-900' %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -1,0 +1,29 @@
+<% set_meta_tags title: "管理者ページ | 投稿詳細" %>
+
+<div class="container mx-auto px-4 py-16">
+  <div class="max-w-xl mx-auto bg-white p-8 rounded-lg shadow-md">
+    <h1 class="text-3xl font-bold text-gray-800 mb-6 text-center">投稿詳細</h1>
+    <div class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+     <span>投稿ID: </span> <%= @post.id %>
+    </div>
+    <div class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+      <span>投稿ワード: </span> <%= @post.post_word %>
+    </div>
+    <div class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+      <span>キャプション:  </span><%= @post.caption %>
+    </div>
+    <div class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+      <span>投稿者:  </span><%= @post.user.username %>
+    </div>
+    <div class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+      <span>投稿日時: </span> <%= l @post.created_at, format: :short %>
+    </div>
+    <div class="px-5 py-5 border-b border-gray-200 bg-white text-sm text-center">
+      <%= link_to '編集', edit_admin_post_path(@post), class: 'text-indigo-600 hover:text-indigo-900 mr-4' %>
+      <%= link_to '削除', admin_post_path(@post),
+                          data: { turbo_method: :delete, turbo_confirm: '本当にこの投稿を削除しますか？' },
+                          class: 'text-red-600 hover:text-red-900' %>
+      <%= link_to '一覧', admin_posts_path, class: 'text-indigo-600 hover:text-indigo-900 mr-4' %>
+    </div>                        
+  </div>
+</div>

--- a/app/views/ai_messages/show.html.erb
+++ b/app/views/ai_messages/show.html.erb
@@ -1,5 +1,5 @@
 <div id="positive-word-id-<%= @positive_word.id %>">
-  <div  data-controller="reload-on-back"  class="flex items-center justify-center px-4">
+  <div data-controller="reload-on-back"  class="flex items-center justify-center px-4">
     <div class="mt-20 max-w-3xl w-full bg-rose-50 rounded-2xl shadow-lg overflow-hidden">
       <div class="bg-pink-100 py-8 px-6 rounded-t-2xl border-b border-red-200">
         <h2 class="text-center text-2xl font-bold text-pink-600">

--- a/app/views/posts/_card.html.erb
+++ b/app/views/posts/_card.html.erb
@@ -20,7 +20,7 @@
     <% end %>
 
     <div class="bg-gray-50 px-6 py-3 flex justify-end items-center space-x-2 border-t border-gray-200 rounded-b-xl">
-      <% if current_user.own?(post) %>
+      <% if current_user.own?(post)  || current_user.admin?  %>
         <!-- 編集 -->
         <%= link_to edit_post_path(post), id: "button-edit-#{post.id}", class: 'text-sm text-gray-700 hover:underline', data: { turbo: false }, title: "編集" do %>
           <i class="bi bi-pencil-fill"></i>編集

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -86,6 +86,10 @@
     <% end %>
   </div>
 
+  <% if current_user&.admin? %>
+    <%= link_to '投稿管理ページ', admin_posts_path, class: 'text-gray-500 text-lg block hover:text-gray-700 hover:underline' %>
+  <% end %>
+
   <%= link_to 'お問い合わせ', new_contact_path, class: 'text-gray-500 text-lg block hover:text-gray-700 hover:underline' %>
   <%= link_to '利用規約', page_path('term_of_service'), class: 'text-gray-500 text-lg block hover:text-gray-700 hover:underline' %>
   <%= link_to 'プライバシーポリシー', page_path('policy'), class: 'text-gray-500 text-lg block hover:text-gray-700 hover:underline' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Rails.application.routes.draw do
       get :favorites_autocomplete
     end
   end
+
+  namespace :admin do
+    resources :posts, only: [:index, :new, :create, :show, :edit, :update ,:destroy]
+  end
+  
   resources :post_favorites, only: %i[create destroy]
   
   resources :contacts, only: [:new, :create]

--- a/db/migrate/20250715060955_add_admin_to_users.rb
+++ b/db/migrate/20250715060955_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_06_063547) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_15_060955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,7 +40,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_06_063547) do
     t.integer "target_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "source_type", default: 1
   end
 
   create_table "post_favorites", force: :cascade do |t|
@@ -94,6 +93,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_06_063547) do
     t.string "unconfirmed_email"
     t.string "provider"
     t.string "uid"
+    t.boolean "admin", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -240,3 +240,12 @@ target_data[:situations].each do |situation_name|
         end
       end
     end
+
+if ENV["ADMIN_EMAIL"].present? && ENV["ADMIN_PASSWORD"].present?
+  User.find_or_create_by!(email: ENV["ADMIN_EMAIL"]) do |user|
+    user.username = "admin"
+    user.password = ENV["ADMIN_PASSWORD"]
+    user.password_confirmation = ENV["ADMIN_PASSWORD"]
+    user.admin = true
+  end
+end


### PR DESCRIPTION
# 概要
**卒業制作⑰本リリース後**
管理者画面の追加

スパム対策に、投稿ページの管理者権限を強化。

# 実装内容
- [x] Userモデルに `admin:boolean` カラムを追加（デフォルト false）
- [x] seeds.rb にて ENV 変数から管理者ユーザーを作成
- [x] `Admin::PostsController` を作成し、投稿の管理専用画面を追加
- [x] `namespace :admin` を使ってルーティングを分離
- [x] `before_action :if_not_admin` によるアクセス制御を実装
- [x] 投稿管理一覧ページ、詳細ページ、編集ページを作成
- [x] 管理者ページへのリンクを管理者がログインしたときのみ表示するように実装 

# 確認方法
- [x] seeds.rb で管理者が作成される
- [x] 管理者でログイン後 `/admin/posts` にアクセス可能
- [x] 通常ユーザーでは `/admin/posts` にアクセスすると `root_path` にリダイレクトされる
- [x] 管理者が投稿を編集・削除できる
- [x] 通常ユーザーが他人の投稿に不正アクセスできない

# 関連Issue
Closes #160

