### PR TITLE
 投稿のソート機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,6 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   helper_method :prepare_meta_tags
 
-  rescue_from ActiveRecord::RecordNotFound, with: :render_404
-  rescue_from ActionController::RoutingError, with: :render_404
-  rescue_from StandardError, with: :render_500
 
   private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,9 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   helper_method :prepare_meta_tags
 
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
+  rescue_from StandardError, with: :render_500
 
   private
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -95,14 +95,14 @@ class PostsController < ApplicationController
   end
 
   private
-  
+
   def apply_sorting(scope)
     case params[:sort]
-    when 'latest'
+    when "latest"
       scope.latest
-    when 'old'
+    when "old"
       scope.old
-    when 'most_favorited'
+    when "most_favorited"
       scope.most_favorited
     else
       scope

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,15 +5,7 @@ class PostsController < ApplicationController
     set_meta_tags title: "みんなのポジほめワード"
 
     @q = Post.ransack(params[:q])
-    posts_scope = @q.result
-
-    # ソート処理
-    case params[:sort]
-    when 'latest'
-      posts_scope = posts_scope.latest
-    when 'old'
-      posts_scope = posts_scope.old
-    end
+    posts_scope = apply_sorting(@q.result)
 
     @posts = Posts::PostFetcher.new(posts_scope, params).call
 
@@ -26,15 +18,7 @@ class PostsController < ApplicationController
     set_meta_tags title: "お気に入り登録ページ"
 
     @q = current_user.favorite_posts.ransack(params[:q])
-    posts_scope = @q.result
-
-    # ソート処理
-    case params[:sort]
-    when 'latest'
-      posts_scope = posts_scope.latest
-    when 'old'
-      posts_scope = posts_scope.old
-    end
+    posts_scope = apply_sorting(@q.result)
 
     @post_favorites = Posts::PostFetcher.new(posts_scope, params).call
 
@@ -111,6 +95,19 @@ class PostsController < ApplicationController
   end
 
   private
+  
+  def apply_sorting(scope)
+    case params[:sort]
+    when 'latest'
+      scope.latest
+    when 'old'
+      scope.old
+    when 'most_favorited'
+      scope.most_favorited
+    else
+      scope
+    end
+  end
 
   def post_params
     params.require(:post).permit(:post_word, :caption)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,9 @@ class Post < ApplicationRecord
 
   validates :post_word, presence: true, length: { maximum: 255 }
 
+  scope :latest, -> {order(created_at: :desc)}
+  scope :old, -> {order(created_at: :asc)}
+
   def self.ransackable_attributes(auth_object = nil)
     [ "post_word", "caption" ]
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,13 +6,13 @@ class Post < ApplicationRecord
 
   validates :post_word, presence: true, length: { maximum: 255 }
 
-  scope :latest, -> {order(created_at: :desc)}
-  scope :old, -> {order(created_at: :asc)}
+  scope :latest, -> { order(created_at: :desc) }
+  scope :old, -> { order(created_at: :asc) }
   scope :most_favorited, -> {
     left_joins(:post_favorites)
-    .select('posts.*, COUNT(post_favorites.id) AS favorites_count')
-    .group('posts.id')
-    .order('favorites_count DESC')
+    .select("posts.*, COUNT(post_favorites.id) AS favorites_count")
+    .group("posts.id")
+    .order("favorites_count DESC")
   }
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,6 +8,12 @@ class Post < ApplicationRecord
 
   scope :latest, -> {order(created_at: :desc)}
   scope :old, -> {order(created_at: :asc)}
+  scope :most_favorited, -> {
+    left_joins(:post_favorites)
+    .select('posts.*, COUNT(post_favorites.id) AS favorites_count')
+    .group('posts.id')
+    .order('favorites_count DESC')
+  }
 
   def self.ransackable_attributes(auth_object = nil)
     [ "post_word", "caption" ]

--- a/app/views/posts/_search.html.erb
+++ b/app/views/posts/_search.html.erb
@@ -7,7 +7,7 @@
     <div class="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-2">
 
       <%= select_tag :sort,
-          options_for_select([["投稿の新しい順", "latest"], ["投稿の古い順", "old"]], params[:sort] || "latest"),
+          options_for_select([["投稿の新しい順", "latest"], ["投稿の古い順", "old"], ["人気順", "most_favorited"]], params[:sort] || "latest"),
           onchange: "this.form.submit()",
           class: "bg-white border border-gray-300 px-3 py-2 rounded-md text-gray-700" %>
 

--- a/app/views/posts/_search.html.erb
+++ b/app/views/posts/_search.html.erb
@@ -3,17 +3,24 @@
        data-controller="autocomplete"
        data-autocomplete-url-value="<%= autocomplete_url %>"
        role="combobox">
-    
-    <div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
+
+    <div class="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-2">
+
+      <%= select_tag :sort,
+          options_for_select([["投稿の新しい順", "latest"], ["投稿の古い順", "old"]], params[:sort] || "latest"),
+          onchange: "this.form.submit()",
+          class: "bg-white border border-gray-300 px-3 py-2 rounded-md text-gray-700" %>
+
       <%= f.text_field :post_word_or_caption_cont,
-        class: 'flex-grow bg-white p-2  mr-1 border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 focus:ring-red-300 rounded-md',
+        class: 'flex-grow bg-white p-2 border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 focus:ring-red-300 rounded-md',
         placeholder: 'ワードまたはキャプションで検索',
         data: { autocomplete_target: "input" } %>
 
       <%= f.submit '検索',
-        class: 'whitespace-nowrap text-white bg-red-400 hover:bg-red-500 mb-2 px-4 py-2 rounded-md shadow-md w-full sm:w-auto' %>
+        class: 'text-white bg-red-400 hover:bg-red-500 px-4 py-2 rounded-md shadow-md w-full sm:w-auto' %>
     </div>
 
+    <!-- オートコンプリート結果 -->
     <ul class="absolute z-50 mt-1 bg-white w-full rounded-md text-sm"
         data-autocomplete-target="results">
     </ul>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -37,6 +37,7 @@
       </div>
 
       <div class="mt-8">
+
        <% if @posts.present? %>
           <%= render partial: 'posts/posts_list', locals: { posts: @posts } %>
         <% else %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -37,7 +37,7 @@
       </div>
 
       <div class="mt-8">
-        <% if @posts.present? %>
+       <% if @posts.present? %>
           <%= render partial: 'posts/posts_list', locals: { posts: @posts } %>
         <% else %>
           <p class="text-gray-600 italic text-center">まだ投稿はありません。</p>


### PR DESCRIPTION
# 概要
**卒業制作⑰本リリース後**
投稿のソート機能

ユーザー体験向上のため投稿ページ・投稿のお気に入りページにソート機能の実装

# 実装内容
- [x] 投稿に新しい順・古い順・人気順でソート検索できるようにする
- postモデルに検索用のスコープを作る
```ruby
  scope :latest, -> { order(created_at: :desc) }
  scope :old, -> { order(created_at: :asc) }
  scope :most_favorited, -> {
    left_joins(:post_favorites)
    .select("posts.*, COUNT(post_favorites.id) AS favorites_count")
    .group("posts.id")
    .order("favorites_count DESC")
  }
 ```

- postコントローラーにソート処理用のprivateメソッド apply_sorting を追加
```ruby
  def apply_sorting(scope)
    case params[:sort]
    when "latest"
      scope.latest
    when "old"
      scope.old
    when "most_favorited"
      scope.most_favorited
    else
      scope
    end
  end
```
- posts/_search.html.erbにソートするためのselectボックスを追加
```ruby
      <%= select_tag :sort,
          options_for_select([["投稿の新しい順", "latest"], ["投稿の古い順", "old"], ["人気順", "most_favorited"]], params[:sort] || "latest"),
          onchange: "this.form.submit()",
          class: "bg-white border border-gray-300 px-3 py-2 rounded-md text-gray-700" %>

```

- [x] 投稿のお気に入りページにも新しい順・古い順・人気順でソート検索できるようにする
- postコントローラーのpost_favorites部分にアクションを追記

# 確認方法
- [x] /postsでソートかけた時に、新しい順なら先頭に最新の日付の投稿が、古い順なら古い日付になっている
- [x] /postsで人気順にソートかけた時に、人気順になっている
- [x] 検索をかけてもソートが崩れない
- [x] お気に入り登録ページでも 同様の動きが確認できる

# 関連Issue
Closes #162

