### PR TITLE
ユーザーページのソート機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,6 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   helper_method :prepare_meta_tags
 
-  rescue_from ActiveRecord::RecordNotFound, with: :render_404
-  rescue_from ActionController::RoutingError, with: :render_404
-  rescue_from StandardError, with: :render_500
 
   private
 

--- a/app/controllers/userpages_controller.rb
+++ b/app/controllers/userpages_controller.rb
@@ -69,7 +69,11 @@ class UserpagesController < ApplicationController
   def destroy
     @custom_word = current_user.positive_words.find(params[:id])
     @custom_word.destroy!
-    word_data = Userpages::WordFetcher.new(current_user, params)
+    
+    # 検索・並び替え済みスコープを渡す
+    q = current_user.positive_words.ransack(params[:q])
+    words_scope = apply_sorting(q.result)
+    word_data = Userpages::WordFetcher.new(words_scope, params)
 
     # Turboのためワードのカウント数を再度取得
     @custom_words = word_data.custom_words

--- a/app/controllers/userpages_controller.rb
+++ b/app/controllers/userpages_controller.rb
@@ -69,7 +69,7 @@ class UserpagesController < ApplicationController
   def destroy
     @custom_word = current_user.positive_words.find(params[:id])
     @custom_word.destroy!
-    
+
     # 検索・並び替え済みスコープを渡す
     q = current_user.positive_words.ransack(params[:q])
     words_scope = apply_sorting(q.result)

--- a/app/controllers/userpages_controller.rb
+++ b/app/controllers/userpages_controller.rb
@@ -7,7 +7,9 @@ class UserpagesController < ApplicationController
 
     # 検索フォーム
     @q = current_user.positive_words.ransack(params[:q])
-    word_data = Userpages::WordFetcher.new(current_user, params)
+    words_scope = apply_sorting(@q.result)
+
+    word_data = Userpages::WordFetcher.new(words_scope, params)
 
     # ワードのカウント数
     @favorited_words = word_data.favorited_words
@@ -89,6 +91,17 @@ class UserpagesController < ApplicationController
   end
 
   private
+
+  def apply_sorting(scope)
+    case params[:sort]
+    when "latest"
+      scope.latest
+    when "old"
+      scope.old
+    else
+      scope
+    end
+  end
 
   def positive_word_params
     params.require(:positive_word).permit(:word, :is_custom)

--- a/app/models/positive_word.rb
+++ b/app/models/positive_word.rb
@@ -11,6 +11,9 @@ class PositiveWord < ApplicationRecord
   validates :target, presence: true, unless: :is_custom?
   validates :word, presence: true, if: -> { is_custom? || persisted? }
 
+  scope :latest, -> { order(created_at: :desc) }
+  scope :old, -> { order(created_at: :asc) }
+
   def self.ransackable_attributes(auth_object = nil)
     [ "word" ]
   end

--- a/app/models/userpages/word_fetcher.rb
+++ b/app/models/userpages/word_fetcher.rb
@@ -1,19 +1,12 @@
 class Userpages::WordFetcher
   attr_reader :searched_words, :favorited_words, :custom_words, :favorited_ids
 
-  def initialize(user, params)
-    @user = user
+  def initialize(words_scope, params)
     @params = params
-    @favorited_ids = user.favorited_words.pluck(:positive_word_id)
-    run_query
-  end
-
-  private
-
-  def run_query
-    q = @user.positive_words.ransack(@params[:q])
-    @searched_words = q.result(distinct: true).includes(:situation, :target).order(created_at: :desc)
-    @favorited_words = @searched_words.where(id: favorited_ids)
-    @custom_words = @searched_words.where(is_custom: true).where.not(id: favorited_ids)
+    user = words_scope.first&.user
+    @favorited_ids = user ? (words_scope.pluck(:id) & user.favorited_words.pluck(:positive_word_id)) : []
+    @searched_words = words_scope.includes(:situation, :target)
+    @favorited_words = @searched_words.where(id: @favorited_ids)
+    @custom_words = @searched_words.where(is_custom: true).where.not(id: @favorited_ids)
   end
 end

--- a/app/views/posts/_search.html.erb
+++ b/app/views/posts/_search.html.erb
@@ -7,7 +7,7 @@
     <div class="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-2">
 
       <%= select_tag :sort,
-          options_for_select([["投稿の新しい順", "latest"], ["投稿の古い順", "old"], ["人気順", "most_favorited"]], params[:sort] || "latest"),
+          options_for_select([["新しい順", "latest"], ["古い順", "old"], ["人気順", "most_favorited"]], params[:sort] || "latest"),
           onchange: "this.form.submit()",
           class: "bg-white border border-gray-300 px-3 py-2 rounded-md text-gray-700" %>
 

--- a/app/views/userpages/_search.html.erb
+++ b/app/views/userpages/_search.html.erb
@@ -5,6 +5,12 @@
        role="combobox">
     
     <div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
+
+      <%= select_tag :sort,
+          options_for_select([["新しい順", "latest"], ["古い順", "old"]], params[:sort] || "latest"),
+          onchange: "this.form.submit()",
+          class: "bg-white border border-gray-300 px-3 py-2 rounded-md text-gray-700" %>
+
       <%= f.text_field :word_cont,
         class: 'flex-grow bg-white p-2  mr-1 border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 focus:ring-yellow-300 rounded-md',
         placeholder: 'ワード検索',

--- a/spec/system/comment_spec.rb
+++ b/spec/system/comment_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe 'Comments', type: :system do
           click_on '更新'
         end
   
-        within("#comment-#{own_comment.id}", visible: true, wait: 5) do
-          expect(page).to have_text('更新されたコメント', wait: 5), '編集内容が反映されていません'
+        within("#comment-#{own_comment.id}", visible: true, wait: 10) do
+          expect(page).to have_text('更新されたコメント', wait: 10), '編集内容が反映されていません'
         end
       end
     end


### PR DESCRIPTION
# 概要
**卒業制作⑰本リリース後**
ユーザーページのソート機能

ユーザー体験向上のためユーザーページにソート機能の実装

# 実装内容
- [x] ユーザーページに新しい順・古い順でソート検索できるようにする
- positive_wordsモデルに検索用のスコープを作る
```ruby
  scope :latest, -> { order(created_at: :desc) }
  scope :old, -> { order(created_at: :asc) }
 ```

- userpagesコントローラーにソート処理用のprivateメソッド apply_sorting を追加
```ruby
  def apply_sorting(scope)
    case params[:sort]
    when "latest"
      scope.latest
    when "old"
      scope.old
    else
      scope
    end
  end
```
- userpages/wordfetcher.rbで検索結果とワードの種別の責務から、ワードの種別だけを行ってもらうように変更
```ruby
class Userpages::WordFetcher
  attr_reader :searched_words, :favorited_words, :custom_words, :favorited_ids

  def initialize(words_scope, params)
    @params = params
    user = words_scope.first&.user
    @favorited_ids = user ? (words_scope.pluck(:id) & user.favorited_words.pluck(:positive_word_id)) : []
    @searched_words = words_scope.includes(:situation, :target)
    @favorited_words = @searched_words.where(id: @favorited_ids)
    @custom_words = @searched_words.where(is_custom: true).where.not(id: @favorited_ids)
  end
end
```

- userpases/_search.html.erbにソートするためのselectボックスを追加
```ruby
      <%= select_tag :sort,
          options_for_select([["投稿の新しい順", "latest"], ["投稿の古い順", "old"], ["人気順", "most_favorited"]], params[:sort] || "latest"),
          onchange: "this.form.submit()",
          class: "bg-white border border-gray-300 px-3 py-2 rounded-md text-gray-700" %>

```


# 確認方法
- [x] /userpagesでソートかけた時に、新しい順なら先頭に最新の日付の投稿が、古い順なら古い日付になっている
- [x] お気に入りのワード、カスタムワードどちらもソートがかけられる
- [x] 検索をかけてもソートが崩れない


# 関連Issue
Closes #168

