### PR TITLE
ログイン周りのi18nの強化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,10 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   helper_method :prepare_meta_tags
 
-
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
+  rescue_from StandardError, with: :render_500
+  
   private
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from ActionController::RoutingError, with: :render_404
   rescue_from StandardError, with: :render_500
-  
+
   private
 
   def after_sign_in_path_for(resource)

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,8 +1,8 @@
-<% set_meta_tags title: "確認メールの再送" %>
+<% set_meta_tags title: t('.resend_confirmation_instructions') %>
 <div class="flex items-center justify-center px-4">
   <div class="mt-20 max-w-3xl w-full bg-white rounded-2xl shadow-lg overflow-hidden p-8">
     <h2 class="text-center text-2xl sm:text-3xl font-semibold tracking-tight text-blue-600 mb-6">
-      確認メールの再送
+      <%= t('.resend_confirmation_instructions') %>
     </h2>
 
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
@@ -18,7 +18,7 @@
       </div>
 
       <div>
-        <%= f.submit "確認メールを再送", class: "w-full flex justify-center rounded-full bg-blue-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+        <%= f.submit t('.resend_confirmation_instructions'), class: "w-full flex justify-center rounded-full bg-blue-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
     <% end %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,8 +1,8 @@
-<% set_meta_tags title: "パスワードを変更" %>
+<% set_meta_tags title:  t('.change_your_password') %>
 <div class="flex items-center justify-center px-4">
   <div class="mt-20 max-w-3xl w-full bg-white rounded-2xl shadow-lg overflow-hidden p-8">
     <h2 class="text-center text-2xl sm:text-3xl font-semibold tracking-tight text-blue-600 mb-6">
-      パスワードを変更
+      <%= t('.change_your_password') %>
     </h2>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-4" }) do |f| %>
@@ -10,20 +10,20 @@
       <%= f.hidden_field :reset_password_token %>
 
       <div>
-        <%= f.label :password, "新しいパスワード", class: "block text-lg sm:text-xl font-medium text-gray-700" %>
+        <%= f.label :password, t('.new_password'), class: "block text-lg sm:text-xl font-medium text-gray-700" %>
         <% if @minimum_password_length %>
           <em class="text-sm text-gray-500">(<%= @minimum_password_length %> 文字以上)</em>
         <% end %>
-        <%= f.password_field :password, placeholder: "6文字以上のパスワードを入力", autofocus: true, autocomplete: "new-password", class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+        <%= f.password_field :password, placeholder: t('.password_must_be_at_least_6_characters'), autofocus: true, autocomplete: "new-password", class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 
       <div>
-        <%= f.label :password_confirmation, "新しいパスワードの確認", class: "block text-lg sm:text-xl font-medium text-gray-700" %>
-        <%= f.password_field :password_confirmation, placeholder: "パスワードを再入力", autocomplete: "new-password", class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+        <%= f.label :password_confirmation, t('.confirm_new_password'), class: "block text-lg sm:text-xl font-medium text-gray-700" %>
+        <%= f.password_field :password_confirmation, placeholder: t('.change_password'), autocomplete: "new-password", class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 
       <div>
-        <%= f.submit "パスワードを変更", class: "w-full flex justify-center rounded-full bg-blue-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+        <%= f.submit t('.change_your_password'), class: "w-full flex justify-center rounded-full bg-blue-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 
       <div class="mt-2 text-center text-base sm:text-lg text-gray-600">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,20 +1,20 @@
-<% set_meta_tags title: "パスワード再設定" %>
+<% set_meta_tags title: t('activerecord.attributes.user.password_confirmation_re_enter') %>
 <div class="flex items-center justify-center px-4">
   <div class="mt-20 max-w-3xl w-full bg-white rounded-2xl shadow-lg overflow-hidden p-8">
     <h2 class="text-center text-2xl sm:text-3xl font-semibold tracking-tight text-blue-600 mb-6">
-      パスワード再設定
+      <%= t('activerecord.attributes.user.password_confirmation_re_enter') %>
     </h2>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div>
-        <%= f.label :email, "登録したメールアドレス", class: "block text-lg sm:text-xl font-medium text-gray-700" %>
+        <%= f.label :email, t('.current_email') , class: "block text-lg sm:text-xl font-medium text-gray-700" %>
         <%= f.email_field :email, placeholder: "example@example.com", autofocus: true, autocomplete: "email", class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 
       <div>
-        <%= f.submit "パスワード再設定の指示を送信", class: "w-full flex justify-center rounded-full bg-blue-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+        <%= f.submit t('.send_me_reset_password_instructions') , class: "w-full flex justify-center rounded-full bg-blue-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
     <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,8 +1,8 @@
-<% set_meta_tags title: "アカウント編集" %>
+<% set_meta_tags title: t('.title')  %>
 <div class="flex items-center justify-center px-4">
   <div class="mt-20 max-w-3xl w-full bg-white rounded-2xl shadow-lg overflow-hidden p-8">
     <h2 class="text-center text-2xl sm:text-3xl font-semibold tracking-tight text-teal-600 mb-6">
-      アカウント編集
+      <%= t('.title') %>
     </h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-4" }) do |f| %>
@@ -10,7 +10,7 @@
 
       <div>
         <%= f.label :username, class: "block text-lg sm:text-xl font-medium text-gray-700" %>
-        <%= f.text_field :username, placeholder: "ユーザー名", autofocus: true, autocomplete: "username",
+        <%= f.text_field :username, placeholder: t('activerecord.attributes.user.username'), autofocus: true, autocomplete: "username",
               class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
       </div>
 
@@ -22,27 +22,26 @@
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %> 
         <div class="text-center text-sm text-gray-600 mt-2">
-          現在確認中のメールアドレス: <%= resource.unconfirmed_email %>
+          <%= t('.current_email') %>: <%= resource.unconfirmed_email %>
         </div>
       <% end %>
 
       <div>
-        <%= f.submit "更新する", class: "w-full flex justify-center rounded-full bg-teal-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-teal-600 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
+        <%= f.submit t('.update'), class: "w-full flex justify-center rounded-full bg-teal-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-teal-600 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
       </div>
     <% end %>
 
     <div class="mt-8 border-t border-gray-200 pt-6 text-center space-y-4">
       <div>
-        <h3 class="text-lg font-semibold text-gray-700 mb-2">アカウントを削除する</h3>
         <%= form_with url: registration_path(resource_name), method: :delete, html: { id: "delete-account-form" } do %>
           <button type="button" onclick="confirmDelete()" class="text-red-600 hover:text-red-500 text-base hover:underline">
-            アカウントを削除
+            <%= t('.cancel_my_account') %>
           </button>
         <% end %>
       </div>
 
       <div>
-        <%= link_to "トップページに戻る", root_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400 hover:underline' %>
+        <%= link_to t('.toppage'), root_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400 hover:underline' %>
       </div>
     </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,8 +1,8 @@
-<% set_meta_tags title: "新規登録" %>
+<% set_meta_tags title: t('.sign_up')  %>
 <div class="flex items-center justify-center px-4">
   <div class="mt-20 max-w-3xl w-full bg-white rounded-2xl shadow-lg overflow-hidden p-8">
     <h2 class="text-center text-2xl sm:text-3xl font-semibold tracking-tight text-teal-600 mb-6">
-      新規登録
+      <%= t('.sign_up') %>
     </h2>
 
     <div class="mt-2 text-center text-base sm:text-lg text-gray-600">
@@ -25,30 +25,30 @@
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div>
-        <%= f.label :username, "ユーザー名", class: "block text-lg sm:text-xl font-medium text-gray-700" %>
-        <%= f.text_field :username, placeholder: "ユーザー名", required: true, autofocus: true, class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
+        <%= f.label :username, t('activerecord.attributes.user.username'), class: "block text-lg sm:text-xl font-medium text-gray-700" %>
+        <%= f.text_field :username, placeholder: t('activerecord.attributes.user.username'), required: true, autofocus: true, class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
       </div>
 
       <div>
-        <%= f.label :email, "メールアドレス", class: "block text-lg sm:text-xl font-medium text-gray-700" %>
+        <%= f.label :email, t('activerecord.attributes.user.email'), class: "block text-lg sm:text-xl font-medium text-gray-700" %>
         <%= f.email_field :email, placeholder: "example@example.com", autocomplete: "email", required: true,  class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
       </div>
 
       <div>
-        <%= f.label :password, "パスワード", class: "block text-lg sm:text-xl font-medium text-gray-700" %>
+        <%= f.label :password, t('activerecord.attributes.user.password'), class: "block text-lg sm:text-xl font-medium text-gray-700" %>
         <% if @minimum_password_length %>
           <em class="text-sm text-gray-500">(<%= @minimum_password_length %> 文字以上)</em>
         <% end %>
-        <%= f.password_field :password, placeholder: "6文字以上のパスワードを入力", autocomplete: "new-password", required: true, class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
+        <%= f.password_field :password, placeholder: t('.password_must_be_at_least_6_characters'), autocomplete: "new-password", required: true, class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
       </div>
 
       <div>
-        <%= f.label :password_confirmation, "パスワード確認", class: "block text-lg sm:text-xl font-medium text-gray-700" %>
-        <%= f.password_field :password_confirmation, placeholder: "パスワードを再入力", autocomplete: "new-password", required: true, class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
+        <%= f.label :password_confirmation, t('activerecord.attributes.user.password_confirmation'), class: "block text-lg sm:text-xl font-medium text-gray-700" %>
+        <%= f.password_field :password_confirmation, placeholder: t('activerecord.attributes.user.password_confirmation_re_enter'), autocomplete: "new-password", required: true, class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500" %>
       </div>
 
       <div>
-        <%= f.submit "登録", class: "w-full flex justify-center rounded-full bg-teal-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-teal-600 focus:outline-none" %>
+        <%= f.submit t('.sign_up') , class: "w-full flex justify-center rounded-full bg-teal-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-teal-600 focus:outline-none" %>
       </div>
     <% end %>
 
@@ -56,7 +56,7 @@
       <%= render "devise/shared/links" %>
     </div>
     <div class="text-sm text-gray-600 mt-4">
-      ※ご登録いただいたメールアドレスは、ログイン、アカウント管理などの目的で利用します。<br>
+      <%= t('.note') %><br>
     </div>
   </div>    
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,8 +1,8 @@
-<% set_meta_tags title: "ログイン" %>
+<% set_meta_tags title: t('.sign_in') %>
 <div class="flex items-center justify-center px-4">
   <div class="max-w-3xl mt-20 w-full bg-white rounded-2xl shadow-lg overflow-hidden p-8">
     <h2 class="text-center text-2xl sm:text-3xl font-semibold tracking-tight text-blue-600 mb-6">
-      ログイン
+      <%= t('.sign_in') %>
     </h2>
 
     <div class="mt-2 text-center text-base sm:text-lg text-gray-600">
@@ -25,24 +25,24 @@
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div>
-        <%= f.label :email, "メールアドレス", class: "block text-lg sm:text-xl font-medium text-gray-700" %>
+        <%= f.label :email, t('activerecord.attributes.user.email'), class: "block text-lg sm:text-xl font-medium text-gray-700" %>
         <%= f.email_field :email, placeholder: "example@example.com", autofocus: true, autocomplete: "email", required: true, class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 
       <div>
-        <%= f.label :password, "パスワード", class: "block text-lg sm:text-xl font-medium text-gray-700" %>
-        <%= f.password_field :password, placeholder: "6文字以上のパスワードを入力", autocomplete: "current-password", required: true, class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+        <%= f.label :password, t('activerecord.attributes.user.password'), class: "block text-lg sm:text-xl font-medium text-gray-700" %>
+        <%= f.password_field :password, placeholder: t('.password_must_be_at_least_6_characters'), autocomplete: "current-password", required: true, class: "mt-2 block w-full rounded-full bg-white px-4 py-3 text-base text-gray-900 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 
       <% if devise_mapping.rememberable? %>
         <div class="mt-4 flex items-center">
           <%= f.check_box :remember_me, class: "h-5 w-5 text-blue-500 border-gray-300 rounded" %>
-          <%= f.label :remember_me, "ログイン情報を保持する", class: "ml-2 text-lg sm:text-xl text-gray-700" %>
+          <%= f.label :remember_me, t('activerecord.attributes.user.remember_me'), class: "ml-2 text-lg sm:text-xl text-gray-700" %>
         </div>
       <% end %>
 
       <div>
-        <%= f.submit "ログイン", class: "w-full flex justify-center rounded-full bg-blue-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+        <%= f.submit t('.sign_in'), class: "w-full flex justify-center rounded-full bg-blue-500 px-4 py-3 text-base font-semibold text-white shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
     <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,19 +1,19 @@
 <%- if controller_name != 'sessions' && !(controller_name == 'top' && action_name == 'index')  %>
-  <%= link_to "ログイン", new_session_path(resource_name) %><br />
+  <%= link_to t('.sign_in'), new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "新規登録はこちら", new_registration_path(resource_name) %><br />
+  <%= link_to t('.sign_up'), new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "パスワードを忘れましたか?", new_password_path(resource_name) %><br />
+  <%= link_to t('.forgot_your_password'), new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "確認メールが届かない場合", new_confirmation_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "ロック解除メールが届かない場合", new_unlock_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
 <% end %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,15 +18,15 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "【ポジほめワード】Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "【ポジほめワード】Reset password instructions"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "【ポジほめワード】Unlock instructions"
       email_changed:
-        subject: "Email Changed"
+        subject: "【ポジほめワード】Email Changed"
       password_change:
-        subject: "Password Changed"
+        subject: "【ポジほめワード】Password Changed"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -17,14 +17,16 @@ ja:
         locked_at: ロック時刻
         password: パスワード
         password_confirmation: パスワード（確認用）
+        password_confirmation_re_enter: パスワードを再入力
         remember_created_at: ログイン記憶時刻
-        remember_me: ログインを記憶する
+        remember_me: ログイン情報を保持する
         reset_password_sent_at: パスワードリセット送信時刻
         reset_password_token: パスワードリセット用トークン
         sign_in_count: ログイン回数
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
+        username: ユーザー名
     models:
       user:
         other: ユーザー
@@ -80,11 +82,14 @@ ja:
       edit:
         change_my_password: パスワードを変更する
         change_your_password: パスワードを変更
-        confirm_new_password: 確認用新しいパスワード
+        confirm_new_password: 新しいパスワードの確認
+        change_password: パスワードを再入力
         new_password: 新しいパスワード
+        password_must_be_at_least_6_characters: 6文字以上のパスワードを入力        
       new:
         forgot_your_password: パスワードを忘れましたか？
         send_me_reset_password_instructions: パスワードの再設定方法を送信する
+        current_email: 登録したメールアドレス
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
       send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
@@ -93,16 +98,20 @@ ja:
     registrations:
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:
-        are_you_sure: 本当によろしいですか？
-        cancel_my_account: アカウント削除
+        are_you_sure: 本当にアカウントを削除しますか？
+        cancel_my_account: アカウントを削除
+        current_email: 現在確認中のメールアドレス
         currently_waiting_confirmation_for_email: '%{email} の確認待ち'
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
-        title: "%{resource}編集"
+        title: アカウント編集
         unhappy: 気に入りません
         update: 更新
+        toppage: トップページに戻る
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
       new:
         sign_up: アカウント登録
+        password_must_be_at_least_6_characters: 6文字以上のパスワードを入力
+        note: ※ご登録いただいたメールアドレスは、ログイン、アカウント管理などの目的で利用します。
       signed_up: アカウント登録が完了しました。
       signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
       signed_up_but_locked: アカウントがロックされているためログインできません。
@@ -114,6 +123,7 @@ ja:
       already_signed_out: 既にログアウト済みです。
       new:
         sign_in: ログイン
+        password_must_be_at_least_6_characters: 6文字以上のパスワードを入力
       signed_in: ログインしました。
       signed_out: ログアウトしました。
     shared:

--- a/spec/system/logins_spec.rb
+++ b/spec/system/logins_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "ログイン機能", type: :system do
       context '認証情報が正しい場合' do
         it 'ログインできること' do
           visit '/users/sign_in'
-          fill_in 'メールアドレス', with: user.email
+          fill_in 'Eメール', with: user.email
           fill_in 'パスワード', with: 'password'
           click_button 'ログイン'
           Capybara.assert_current_path("/", ignore_query: true)
@@ -26,7 +26,7 @@ RSpec.describe "ログイン機能", type: :system do
       context 'PWに誤りがある場合' do
         it 'ログインできないこと' do
           visit '/users/sign_in'
-          fill_in 'メールアドレス', with: user.email
+          fill_in 'Eメール', with: user.email
           fill_in 'パスワード', with: '1234'
           click_button 'ログイン'
           Capybara.assert_current_path("/users/sign_in", ignore_query: true)

--- a/spec/system/registrations_spec.rb
+++ b/spec/system/registrations_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Registrations", type: :system do
   it '新規登録ページにアクセスできること' do
     visit new_user_registration_path
 
-    expect(page).to have_content('新規登録')
+    expect(page).to have_content('アカウント登録')
     expect(page).to have_selector('form')
-    expect(page).to have_title("新規登録 | ポジほめワード"), 'タイトル「新規登録 | ポジほめワード」が表示されていません'
+    expect(page).to have_title("アカウント登録 | ポジほめワード"), 'タイトル「新規登録 | ポジほめワード」が表示されていません'
   end
 
   it '新規登録が成功すること' do
@@ -19,7 +19,7 @@ RSpec.describe "Registrations", type: :system do
     fill_in 'user_password', with: user_attributes[:password]
     fill_in 'user_password_confirmation', with: user_attributes[:password_confirmation]
 
-    click_button '登録'
+    click_button 'アカウント登録'
     Capybara.assert_current_path("/", ignore_query: true)
     expect(page).to have_content('アカウント登録が完了しました。'), 'フラッシュメッセージ「アカウント登録が完了しました。」が表示されていません'
   end
@@ -32,7 +32,7 @@ RSpec.describe "Registrations", type: :system do
     fill_in 'user_password', with: '123'
     fill_in 'user_password_confirmation', with: '1234'
 
-    click_button '登録'
+    click_button 'アカウント登録'
   end
 
   it '入力したメールアドレスがすでに登録されていた場合' do
@@ -45,7 +45,7 @@ RSpec.describe "Registrations", type: :system do
     fill_in 'user_password', with: "password123"
     fill_in 'user_password_confirmation', with: "password123"
 
-    click_button '登録'
+    click_button 'アカウント登録'
     expect(page).to have_content("Eメールはすでに存在します"), 'フラッシュメッセージ「Eメールはすでに存在します」が表示されていません'
   end
 end


### PR DESCRIPTION
# 概要
**卒業制作⑰本リリース後**
ログイン周りのi18nの強化

ログイン周りの言語を日本語で直接コードに記載していたところをi18nに対応化

# 実装内容
- [x] gem devise周りのi18nの強化
- config/locales/devise.views..ja.ymlに足りないないワードを追加
- views/deviseの対応するログインやサインアップ等に直接日本語で記載していたところを`t(...)`に

**例：修正前** 
```ruby
<% set_meta_tags title: ログイン %>
```

  **例：修正後** 
```ruby
<% set_meta_tags title: t('.sign_in') %>
```

# 確認方法
- [x] /user/sign_in、/user/sign_up、/users/password/、/users/editでi18n対応されているか


# 関連Issue
Closes #185
